### PR TITLE
Activated coding style checker on entangled-prs.

### DIFF
--- a/entangled-prs/pipeline.yml
+++ b/entangled-prs/pipeline.yml
@@ -39,3 +39,13 @@ steps:
         mounts:
           - /conf:/conf
           - /cache:/cache
+  - name: "coding style checker"
+    command: ./tools/ci_format_check 'cclient consensus gossip mam ciri common cppclient tanglescope'
+    agents:
+      queue: dev
+    plugins:
+      docker#v1.3.0:
+        image: "th0br0/iota-buildenv:x86_64"
+        mounts:
+          - /conf:/conf
+          - /cache:/cache


### PR DESCRIPTION
This PR fixed https://github.com/iotaledger/entangled/issues/230. 
Currently checking coding style of C/CPP files include `cclient` `consensus` `gossip` `mam` `ciri` `common` `cppclient` `tanglescope`. Will add other folders if needed.