### PR TITLE
Fix Trinity pipelines

### DIFF
--- a/trinity-desktop-deploy/pipeline.yml
+++ b/trinity-desktop-deploy/pipeline.yml
@@ -1,18 +1,4 @@
 steps:
-  - label: ":inbox_tray: Download and install dependencies"
-    command:
-      # Based on https://github.com/why-jay/osx-init/blob/master/install.sh
-      # Install Homebrew
-      - "ruby -e '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)'"
-      # Install NodeJS and Yarn
-      - "brew install node@8 && brew install yarn --without-node"
-      # Install Electron
-      - "yarn global add electron"
-    agents:
-      queue: mac
-
-  - wait
-
   - label: ":hammer_and_wrench: Build for all platforms"
     command:
       - "yarn"
@@ -20,26 +6,18 @@ steps:
       - "cd src/desktop && npm install"
       - "./bugsnag.sh && node bugsnag.js"
       - "npm run build && electron-builder -mwl"
-    artifact_paths:
-      - "out/*"
     agents:
       queue: mac
     env:
       WIN_CSC_LINK: "./cert.p12"
 
-  - wait: ~
-    continue_on_failure: true
-    # We want to clean up the workspace even if the build failed
-
-  - label: "Clean up workspace"
+  - label: ":amazon-s3: Upload artifacts to Amazon S3"
     command:
-      # Uninstall Electron
-      - "yarn global remove electron"
-      # Clean the Yarn cache
-      - "yarn cache clean"
-      # Uninstall NodeJS and Yarn
-      - "brew uninstall yarn && brew install node@8"
-      # Uninstall Homebrew
-      - "ruby -e '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)'"
+      - "cd out"
+      - "buildkite-agent artifact upload "builder-effective-config.yaml" s3://$S3_BUCKET/$BUILDKITE_JOB_ID"
+      - "buildkite-agent artifact upload "latest*" s3://$S3_BUCKET/$BUILDKITE_JOB_ID"
+      - "buildkite-agent artifact upload "trinity-desktop*" s3://$S3_BUCKET/$BUILDKITE_JOB_ID"
     agents:
       queue: mac
+    env:
+      S3_BUCKET: "bucket_name"

--- a/trinity-desktop-prs/pipeline.yml
+++ b/trinity-desktop-prs/pipeline.yml
@@ -12,4 +12,3 @@ steps:
     plugins:
       docker#v1.4.0:
         image: "iotacafe/trinity-desktop-ci:1b7a246-4"
-        always-pull: true

--- a/trinity-mobile-prs/pipeline.yml
+++ b/trinity-mobile-prs/pipeline.yml
@@ -13,4 +13,3 @@ steps:
     plugins:
       docker#v1.4.0:
         image: "iotacafe/trinity-mobile-ci:1b7a246-2"
-        always-pull: true


### PR DESCRIPTION
Removes dependency installation/cleanup from `trinity-desktop-deploy`
Adds S3 artifact upload to `trinity-desktop-deploy`
Removes `always-pull` from `trinity-desktop-prs` and `trinity-mobile-prs`