### PR TITLE
Use npm to install dependencies for Trinity Desktop (PRs)

### DIFF
--- a/trinity-desktop-prs/pipeline.yml
+++ b/trinity-desktop-prs/pipeline.yml
@@ -3,10 +3,10 @@ steps:
     command:
       - "yarn"
       - "cd src/shared && yarn && cd ../.."
-      - "cd src/desktop && yarn && cd ../.."
+      - "cd src/desktop && npm install && cd ../.."
       - "cd src/shared && yarn audit && cd ../desktop && yarn audit && cd ../.."
       - "yarn lint:shared && yarn lint:desktop"
-      - "cd src/desktop && yarn build"
+      - "cd src/desktop && npm run build"
     agents:
       queue: dev
     plugins:


### PR DESCRIPTION
The tests for https://github.com/iotaledger/trinity-wallet/pull/481 seem to be failing because the dependencies are being installed with `yarn` instead of `npm`