### PR TITLE
Trinity pipeline updates

### DIFF
--- a/trinity-desktop-prs/pipeline.yml
+++ b/trinity-desktop-prs/pipeline.yml
@@ -11,4 +11,4 @@ steps:
       queue: dev
     plugins:
       https://github.com/iotaledger/docker-buildkite-plugin#release-v2.0.0:
-        image: "iotacafe/trinity-desktop-ci:83304c4-9"
+        image: "iotacafe/trinity-desktop-ci:latest"

--- a/trinity-mobile-prs/pipeline.yml
+++ b/trinity-mobile-prs/pipeline.yml
@@ -12,4 +12,4 @@ steps:
       queue: dev
     plugins:
       https://github.com/iotaledger/docker-buildkite-plugin#release-v2.0.0:
-        image: "iotacafe/trinity-mobile-ci:583b99c-3"
+        image: "iotacafe/trinity-mobile-ci:latest"

--- a/trinity-shared-prs/pipeline.yml
+++ b/trinity-shared-prs/pipeline.yml
@@ -10,4 +10,4 @@ steps:
       queue: dev
     plugins:
       https://github.com/iotaledger/docker-buildkite-plugin#release-v2.0.0:
-        image: "node:8.12-stretch"
+        image: "node:8.15-stretch"


### PR DESCRIPTION
- Update trinity-shared-prs to `node:8.15-stretch`
- Use latest image for desktop and mobile pipelines