### PR TITLE
Trinity Desktop: Create pipeline for internal testing

### DIFF
--- a/trinity-desktop-internal-build/pipeline.yml
+++ b/trinity-desktop-internal-build/pipeline.yml
@@ -1,0 +1,55 @@
+steps:
+  - label: ":hammer_and_wrench: Build for macOS platform"
+    command:
+      - "yarn"
+      - "cd src/shared && yarn && cd ../.."
+      - "cd src/desktop && npm install"
+      - "./bugsnag.sh && npm run build"
+      - "security unlock-keychain -p $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain && security set-key-partition-list -S apple-tool:,apple: -s -k $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain"
+      - "./node_modules/.bin/electron-builder --mac --x64 --publish=never"
+      - "security lock-keychain BuildkiteKeychain.keychain"
+      - "cd out"
+      - "for i in `ls trinity-desktop*` ; do shasum -a 256 $$i | awk {'print $$1'} > $$i.sha256 ; done"
+    agents:
+      queue: mac
+    artifact_paths:
+      - "src/desktop/out/builder-effective-config.yaml"
+      - "src/desktop/out/latest*"
+      - "src/desktop/out/trinity-desktop*"
+
+  - label: ":hammer_and_wrench: Build for Linux platform"
+    command:
+      - "yarn"
+      - "cd src/shared && yarn && cd ../.."
+      - "cd src/desktop && npm install"
+      - "./bugsnag.sh && npm run build"
+      - "./node_modules/.bin/electron-builder --linux --x64 --publish=never"
+      - "cd out"
+      - "echo $$GPG_CONTACT_IOTA_ORG_PASSPHRASE | gpg --pinentry-mode loopback --batch --passphrase-fd 0 --armor --detach-sign --default-key contact@iota.org trinity-desktop*.AppImage"
+      - "for i in `ls trinity-desktop*` ; do sha256sum $$i | awk {'print $$1'} > $$i.sha256 ; done"
+    plugins:
+       https://github.com/iotaledger/docker-buildkite-plugin#release-v1.4.0:
+         image: "iotacafe/trinity-desktop-ci:83304c4-9"
+         shell: "/bin/sh -e -c"
+         environment:
+           - BUGSNAG_KEY
+           - GPG_CONTACT_IOTA_ORG_PASSPHRASE
+         mounts:
+           - /conf/ssh:/root/.ssh
+           - /conf/gnupg:/root/.gnupg
+    agents:
+      queue: ops
+    artifact_paths:
+      - "src/desktop/out/builder-effective-config.yaml"
+      - "src/desktop/out/latest*"
+      - "src/desktop/out/trinity-desktop*"
+      - "src/desktop/package.json"
+
+  - label: ":hammer_and_wrench: Build for Windows platform"
+    command:
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+    agents:
+      queue: ec2-win-t2medium
+    artifact_paths:
+      - "latest*"
+      - "trinity-desktop*"


### PR DESCRIPTION
This pipeline is basically the same as `trinity-desktop-deploy`, but it doesn't report the build or upload the sourcemap to Bugsnag. This allows us to create builds on CI for internal testing, while ensuring that the sourcemaps in Bugsnag are not overwritten.