### PR TITLE
Revert "Trinity: Bundle JS for Windows app without concurrency"

### DIFF
--- a/trinity-desktop-deploy/pipeline.yml
+++ b/trinity-desktop-deploy/pipeline.yml
@@ -48,7 +48,7 @@ steps:
 
   - label: ":hammer_and_wrench: Build for Windows platform"
     command:
-      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build-no-concurrent && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
     agents:
       queue: ec2-win-t2medium
     artifact_paths:

--- a/trinity-desktop-win7-deploy/pipeline.yml
+++ b/trinity-desktop-win7-deploy/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":hammer_and_wrench: Build for Windows 7 platform"
     command:
-      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build-no-concurrent && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
     agents:
       queue: ec2-win-t2medium
     artifact_paths:


### PR DESCRIPTION
This reverts commit 31323690151b3dbefdc7aab00a3859551d1bb642.

`npm run build` is now automatically non-concurrent as of https://github.com/iotaledger/trinity-wallet/commit/20dc983a35af5ad316fc09427de9426646a1138b#diff-8c6763f7de3245bda83eceac1a684ce1R26