### PR TITLE
Trinity: Remove auditjs

### DIFF
--- a/trinity-desktop-prs/pipeline.yml
+++ b/trinity-desktop-prs/pipeline.yml
@@ -4,7 +4,6 @@ steps:
       - "yarn"
       - "yarn deps:shared"
       - "yarn deps:desktop"
-      - "cd src/desktop && yarn auditjs && cd ../.."
       - "yarn lint:desktop"
       - "cd src/desktop && npm run build"
     agents:

--- a/trinity-mobile-prs/pipeline.yml
+++ b/trinity-mobile-prs/pipeline.yml
@@ -4,7 +4,6 @@ steps:
       - "yarn"
       - "yarn deps:shared"
       - "yarn deps:mobile"
-      - "cd src/mobile && yarn auditjs && cd ../.."
       - "yarn lint:mobile"
       - "cd src/mobile && yarn test && cd ../.."
       - "cd src/mobile && react-native bundle --entry-file index.js --platform android --bundle-output android/main.jsbundle --dev true"

--- a/trinity-shared-prs/pipeline.yml
+++ b/trinity-shared-prs/pipeline.yml
@@ -3,7 +3,6 @@ steps:
     command:
       - "yarn"
       - "yarn deps:shared"
-      - "cd src/shared && yarn auditjs && cd ../.."
       - "yarn lint:shared"
       - "cd src/shared && yarn test && cd ../.."
     agents:


### PR DESCRIPTION
The `auditjs` script is being removed from the pipeline because we'll replace it with another tool