### PR TITLE
Trinity: Use npm ci instead of npm install

### DIFF
--- a/trinity-desktop-deploy/pipeline.yml
+++ b/trinity-desktop-deploy/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command:
       - "yarn"
       - "cd src/shared && yarn && cd ../.."
-      - "cd src/desktop && npm install"
+      - "cd src/desktop && npm ci"
       - "./bugsnag.sh && npm run build && node bugsnag.js"
       - "security unlock-keychain -p $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain && security set-key-partition-list -S apple-tool:,apple: -s -k $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain"
       - "./node_modules/.bin/electron-builder --mac --x64 --publish=never"
@@ -21,7 +21,7 @@ steps:
     command:
       - "yarn"
       - "cd src/shared && yarn && cd ../.."
-      - "cd src/desktop && npm install"
+      - "cd src/desktop && npm ci"
       - "./bugsnag.sh && npm run build && node bugsnag.js"
       - "./node_modules/.bin/electron-builder --linux --x64 --publish=never"
       - "cd out"
@@ -48,7 +48,7 @@ steps:
 
   - label: ":hammer_and_wrench: Build for Windows platform"
     command:
-      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm ci && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
     agents:
       queue: ec2-win-t2medium
     artifact_paths:

--- a/trinity-desktop-internal-build/pipeline.yml
+++ b/trinity-desktop-internal-build/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command:
       - "yarn"
       - "cd src/shared && yarn && cd ../.."
-      - "cd src/desktop && npm install"
+      - "cd src/desktop && npm ci"
       - "./bugsnag.sh && npm run build"
       - "security unlock-keychain -p $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain && security set-key-partition-list -S apple-tool:,apple: -s -k $$BUILDKITE_KEYCHAIN_PASSWORD BuildkiteKeychain.keychain"
       - "./node_modules/.bin/electron-builder --mac --x64 --publish=never"
@@ -21,7 +21,7 @@ steps:
     command:
       - "yarn"
       - "cd src/shared && yarn && cd ../.."
-      - "cd src/desktop && npm install"
+      - "cd src/desktop && npm ci"
       - "./bugsnag.sh && npm run build"
       - "./node_modules/.bin/electron-builder --linux --x64 --publish=never"
       - "cd out"
@@ -48,7 +48,7 @@ steps:
 
   - label: ":hammer_and_wrench: Build for Windows platform"
     command:
-      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm ci && bugsnag.sh && npm run build && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
     agents:
       queue: ec2-win-t2medium
     artifact_paths:

--- a/trinity-desktop-prs/pipeline.yml
+++ b/trinity-desktop-prs/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command:
       - "yarn"
       - "yarn deps:shared"
-      - "yarn deps:desktop"
+      - "cd src/desktop && npm ci && cd ../.."
       - "yarn lint:desktop"
       - "cd src/desktop && npm run build"
     agents:

--- a/trinity-desktop-win7-deploy/pipeline.yml
+++ b/trinity-desktop-win7-deploy/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":hammer_and_wrench: Build for Windows 7 platform"
     command:
-      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm install usb && npm install && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
+      - "yarn && cd src/shared && yarn && cd ../.. && cd src/desktop && npm ci && bugsnag.sh && npm run build && node bugsnag.js && .\\node_modules\\.bin\\electron-builder --win --x64 --publish=never && cd ../../ && mv src/desktop/out/latest* . && mv src/desktop/out/trinity-desktop* ."
     agents:
       queue: ec2-win-t2medium
     artifact_paths:


### PR DESCRIPTION
Installs dependencies exactly as specified in `npm-shrinkwrap.json`
https://docs.npmjs.com/cli/ci.html#description