### PR TITLE
iota-lib-rs: add command to update rust version on Mac & Windows

### DIFF
--- a/iota-lib-rs/pipeline.yml
+++ b/iota-lib-rs/pipeline.yml
@@ -80,6 +80,7 @@ steps:
       - set -e
       - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain \$RUSTUP_TOOLCHAIN
       - export PATH=\$PATH:\$HOME/.cargo/bin
+			- rustup update
       - rustup toolchain list
       - rustc --version
       - cargo test --all
@@ -95,7 +96,8 @@ steps:
       - curl -sSf -o rustup-init.exe https://win.rustup.rs
       - rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
       - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
-      - rustup toolchain list
+      - rustup update
+			- rustup toolchain list
       - rustc --version
       - cargo test --all
     concurrency: 1


### PR DESCRIPTION
It seems Rust on Mac & Windows is not clean installed. [This build ](https://buildkite.com/iota-foundation/iota-lib-rs/builds/28#506485d3-983d-4818-b05c-ca292872a875)shows its rustc is still 1.38.0. So we might need to add command to update rust toolchain.