### PR TITLE
Point iri-regression-tests back to "official" TIAB git repo

### DIFF
--- a/iri-regression-tests/pipeline.yml
+++ b/iri-regression-tests/pipeline.yml
@@ -33,7 +33,7 @@ steps:
 
   - name: "Clone TIAB"
     command:
-      - clone --depth 1 https://github.com/sadjy/tiab.git /cache/tiab
+      - clone --depth 1 https://github.com/iotaledger/tiab.git /cache/tiab
     agents:
       queue: ops
     plugins:


### PR DESCRIPTION
Point TIAB to where it should.