### PR TITLE
Upgrade aloe-related steps to python3 container image

### DIFF
--- a/iri-regression-tests/pipeline.yml
+++ b/iri-regression-tests/pipeline.yml
@@ -89,7 +89,7 @@ steps:
       queue: ops
     plugins:
       https://github.com/iotaledger/docker-buildkite-plugin#release-v1.4.0:
-        image: "python:2-alpine"
+        image: "python:3-alpine"
         shell: /bin/sh -c
         mounts:
           - /cache-iri-regression-tests-$BUILDKITE_BUILD_ID:/cache

--- a/iri-regression-tests/run-aloe-step.yml
+++ b/iri-regression-tests/run-aloe-step.yml
@@ -11,7 +11,7 @@
       queue: ops
     plugins:
       https://github.com/iotaledger/docker-buildkite-plugin#release-v1.4.0:
-        image: "python:2-alpine"
+        image: "python:3-alpine"
         shell: /bin/sh -c
         mounts:
           - /cache-iri-regression-tests-$BUILDKITE_BUILD_ID:/cache


### PR DESCRIPTION
Dyrell reported:

```
aloe $FEATURES --verbose --nologcapture --where tests/features/machine1
 in python:2-alpine
'/cache/tests/features/machine1/output.yml' -> 'tests/features/machine1/output.yml'
Traceback (most recent call last):
  File "/cache/iri-regression-venv/bin/aloe", line 5, in <module>
    from aloe import main
  File "/cache/iri-regression-venv/lib/python2.7/site-packages/aloe/__init__.py", line 10, in <module>
    from aloe.registry import (
  File "/cache/iri-regression-venv/lib/python2.7/site-packages/aloe/registry.py", line 15, in <module>
    from aloe.utils import unwrap_function
  File "/cache/iri-regression-venv/lib/python2.7/site-packages/aloe/utils.py", line 7, in <module>
    from functools import lru_cache
ImportError: cannot import name lru_cache
```

Which can be verified:

```
$ python
Python 2.7.17 (default, Oct 19 2019, 23:36:22) 
[GCC 9.2.1 20191008] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from functools import lru_cache
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name lru_cache
>>> 
$ python3
Python 3.7.6 (default, Dec 19 2019, 09:25:23) 
[GCC 9.2.1 20191130] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from functools import lru_cache
>>> 
